### PR TITLE
Script Assets

### DIFF
--- a/src/conduit/cmd/config.go
+++ b/src/conduit/cmd/config.go
@@ -1,3 +1,0 @@
-package cmd
-
-var version = "0.1"

--- a/src/conduit/cmd/deploy.go
+++ b/src/conduit/cmd/deploy.go
@@ -44,19 +44,19 @@ files.`,
 		eng := engine.New()
 		err = eng.Validate(string(data))
 		if err != nil {
+			log.Error(err.Error())
 			log.Fatal("Bad script syntax")
-			log.Fatal(err.Error())
 		}
 		res, err := eng.ExecuteFunction("$local", string(data))
 		if err != nil {
+			log.Debug(err.Error())
 			log.Fatal("Local execution error")
-			log.Fatal(err.Error())
 		}
 		if res != "" && res != "undefined" {
 			log.Info("Local: " + res)
 		}
 		resp, err := client.Put(mailboxes, pattern, string(data),
-			cmd.Flag("name").Value.String())
+			cmd.Flag("name").Value.String(), cmd.Flag("attach").Value.String())
 		if err != nil {
 			log.Debug(err.Error())
 			log.Error("Could not deploy script")
@@ -113,4 +113,5 @@ func init() {
 	deployCmd.Flags().StringP("pattern", "p", "", "Wildcard search for mailboxes.")
 	deployCmd.Flags().StringP("name", "n", "", "Deployment name")
 	deployCmd.Flags().BoolP("no-results", "x", false, "Dont poll for responses.")
+	deployCmd.Flags().StringP("attach", "a", "", "Attach a file asset to this deployment.")
 }

--- a/src/conduit/cmd/deploy_test.go
+++ b/src/conduit/cmd/deploy_test.go
@@ -8,9 +8,12 @@ import (
 )
 
 func TestDeploy(t *testing.T) {
+	mailbox.OpenMemDB()
+	mailbox.CreateDB()
 	os.Create("test.js")
 	file, err := os.OpenFile("test.js", os.O_APPEND|os.O_WRONLY, 0644)
 	file.WriteString("console.log('test');")
+	file.Close()
 
 	mb, err := mailbox.Create("test.test")
 	if err != nil {
@@ -36,7 +39,6 @@ func TestDeploy(t *testing.T) {
 	deployCmd.ParseFlags([]string{"-x"})
 	deployCmd.Run(deployCmd, []string{"test.js", "test.test"})
 
-	file.Close()
 	os.Remove("test.js")
 
 	msg, err := mb.GetMessage()

--- a/src/conduit/cmd/execute.go
+++ b/src/conduit/cmd/execute.go
@@ -23,9 +23,10 @@ import (
 )
 
 var executeCmd = &cobra.Command{
-	Use:   "execute [script]",
-	Short: "Execute a script file.",
-	Long:  `Execute a Javascript file at the specified path.`,
+	Use:     "execute [script]",
+	Short:   "Execute a script file.",
+	Long:    `Execute a Javascript file at the specified path.`,
+	Aliases: []string{"exec"},
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			fmt.Println("No file specified.")

--- a/src/conduit/cmd/root.go
+++ b/src/conduit/cmd/root.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"conduit/info"
 	"conduit/log"
 	"fmt"
 	"github.com/kardianos/osext"
@@ -27,8 +28,9 @@ var cfgFile string
 
 var RootCmd = &cobra.Command{
 	Use:   "conduit",
-	Short: "Conduit v" + version,
-	Long: `Conduit is a client/server package that allows command and management
+	Short: "Conduit v" + info.ConduitVersion,
+	Long: `Conduit ` + info.ConduitVersion + `
+Conduit is a client/server package that allows command and management
 of resources using JavaScript based automation scripts.`,
 }
 
@@ -54,9 +56,9 @@ func initConfig() {
 	exePath, _ := osext.ExecutableFolder()
 	wd, _ := os.Getwd()
 	viper.SetConfigName("conduit") // name of config file (without extension)
-	viper.AddConfigPath(wd)        // adding home directory as first search path
-	viper.AddConfigPath(exePath)   // adding home directory as first search path
-	viper.AutomaticEnv()           // read in environment variables that match
+	viper.AutomaticEnv()
+	viper.AddConfigPath(wd)
+	viper.AddConfigPath(exePath)
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {

--- a/src/conduit/cmd/run.go
+++ b/src/conduit/cmd/run.go
@@ -81,6 +81,19 @@ func runClient(noLoop bool) {
 				}
 			}
 
+			if resp.Asset != "" {
+				assetPath, err := client.DownloadAsset(resp.Asset)
+				if err != nil {
+					client.Respond(resp.Message, "Could not download asset", true)
+					log.Error("Could not download asset")
+					_, err = client.Delete(resp.Message)
+					continue
+				} else {
+					log.Infof("Downloaded asset to %s", assetPath)
+				}
+				eng.SetAsset(assetPath)
+			}
+
 			executionStartTime := time.Now()
 			err := eng.Execute(resp.Body)
 			executionTime := time.Since(executionStartTime)
@@ -108,7 +121,9 @@ func runProxy() {
 	proxy := goproxy.NewProxyHttpServer()
 	proxyAddress := viper.GetString("master.Address")
 	err := http.ListenAndServe(proxyAddress, proxy)
-	log.Fatal(err.Error())
+	if err != nil {
+		log.Fatal(err.Error())
+	}
 }
 
 // runCmd starts a Conduit client in polling mode. It will poll the server for

--- a/src/conduit/engine/asset.go
+++ b/src/conduit/engine/asset.go
@@ -1,0 +1,29 @@
+package engine
+
+import (
+	"github.com/robertkrimen/otto"
+)
+
+func _asset_exists(call otto.FunctionCall) otto.Value {
+	assetObj, _ := call.Otto.Object("$asset")
+	filepathV, _ := assetObj.Get("filepath")
+	if filepathV.IsUndefined() {
+		v, _ := call.Otto.ToValue(false)
+		return v
+	}
+	filepath := filepathV.String()
+	if filepath == "" {
+		v, _ := call.Otto.ToValue(false)
+		return v
+	}
+	exists := fileExists(filepath)
+	v, _ := call.Otto.ToValue(exists)
+	return v
+
+}
+
+func (eng *ScriptEngine) SetAsset(path string) {
+	assetObj, _ := eng.VM.Object("$asset")
+	pathV, _ := eng.VM.ToValue(path)
+	assetObj.Set("filepath", pathV)
+}

--- a/src/conduit/engine/file.go
+++ b/src/conduit/engine/file.go
@@ -215,3 +215,33 @@ func _file_eachFile(call otto.FunctionCall) otto.Value {
 	}
 	return otto.Value{}
 }
+
+func _file_tempFile(call otto.FunctionCall) otto.Value {
+	f, err := ioutil.TempFile("", "conduit")
+	if err != nil {
+		jsThrow(call, err)
+	}
+	defer f.Close()
+	v, _ := otto.ToValue(f.Name())
+	return v
+}
+
+func _file_tempFolder(call otto.FunctionCall) otto.Value {
+	d, err := ioutil.TempDir("", "conduit")
+	if err != nil {
+		jsThrow(call, err)
+	}
+	v, _ := otto.ToValue(d)
+	return v
+}
+
+func _file_join(call otto.FunctionCall) otto.Value {
+	paths := []string{}
+	for idx, _ := range call.ArgumentList {
+		str, _ := call.Argument(idx).ToString()
+		paths = append(paths, str)
+	}
+	pathStr := filepath.Join(paths...)
+	v, _ := otto.ToValue(pathStr)
+	return v
+}

--- a/src/conduit/engine/gzip.go
+++ b/src/conduit/engine/gzip.go
@@ -1,0 +1,68 @@
+package engine
+
+import (
+	"compress/gzip"
+	"fmt"
+	"github.com/robertkrimen/otto"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+func _gzip_compress(call otto.FunctionCall) otto.Value {
+	source, _ := call.Argument(0).ToString()
+	target, _ := call.Argument(1).ToString()
+	reader, err := os.Open(source)
+	if err != nil {
+		jsThrow(call, err)
+	}
+
+	filename := filepath.Base(source)
+	target = filepath.Join(target, fmt.Sprintf("%s.gz", filename))
+	writer, err := os.Create(target)
+	if err != nil {
+		jsThrow(call, err)
+	}
+
+	defer writer.Close()
+
+	archiver := gzip.NewWriter(writer)
+	archiver.Name = filename
+	defer archiver.Close()
+	_, err = io.Copy(archiver, reader)
+	if err != nil {
+		jsThrow(call, err)
+	}
+
+	return otto.Value{}
+}
+
+func _gzip_decompress(call otto.FunctionCall) otto.Value {
+	source, _ := call.Argument(0).ToString()
+	target, _ := call.Argument(1).ToString()
+
+	reader, err := os.Open(source)
+	if err != nil {
+		jsThrow(call, err)
+	}
+
+	archive, err := gzip.NewReader(reader)
+	if err != nil {
+		jsThrow(call, err)
+	}
+
+	defer archive.Close()
+
+	target = filepath.Join(target, archive.Name)
+	writer, err := os.Create(target)
+	if err != nil {
+		jsThrow(call, err)
+	}
+	defer writer.Close()
+
+	_, err = io.Copy(writer, archive)
+	if err != nil {
+		jsThrow(call, err)
+	}
+	return otto.Value{}
+}

--- a/src/conduit/engine/tar.go
+++ b/src/conduit/engine/tar.go
@@ -1,0 +1,114 @@
+package engine
+
+import (
+	"archive/tar"
+	"fmt"
+	"github.com/robertkrimen/otto"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func _tar_compress(call otto.FunctionCall) otto.Value {
+	var (
+		baseDir string
+	)
+	source, _ := call.Argument(0).ToString()
+	target, _ := call.Argument(1).ToString()
+
+	filename := filepath.Base(source)
+	target = filepath.Join(target, fmt.Sprintf("%s.tar", filename))
+	tarfile, err := os.Create(target)
+	if err != nil {
+		jsThrow(call, err)
+	}
+	defer tarfile.Close()
+
+	tarball := tar.NewWriter(tarfile)
+	defer tarball.Close()
+
+	info, err := os.Stat(source)
+	if err != nil {
+		jsThrow(call, err)
+	}
+
+	if info.IsDir() {
+		baseDir = filepath.Base(source)
+	}
+
+	err = filepath.Walk(source,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			header, err := tar.FileInfoHeader(info, info.Name())
+			if err != nil {
+				return err
+			}
+
+			if baseDir != "" {
+				header.Name = filepath.Join(baseDir, strings.TrimPrefix(path, source))
+			}
+
+			if err := tarball.WriteHeader(header); err != nil {
+				return err
+			}
+
+			if info.IsDir() {
+				return nil
+			}
+
+			file, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			defer file.Close()
+			_, err = io.Copy(tarball, file)
+			return err
+		})
+	return otto.Value{}
+}
+
+func _tar_decompress(call otto.FunctionCall) otto.Value {
+	source, _ := call.Argument(0).ToString()
+	target, _ := call.Argument(1).ToString()
+
+	reader, err := os.Open(source)
+	if err != nil {
+		jsThrow(call, err)
+	}
+	defer reader.Close()
+	tarReader := tar.NewReader(reader)
+
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			jsThrow(call, err)
+		}
+
+		path := filepath.Join(target, header.Name)
+		info := header.FileInfo()
+		if info.IsDir() {
+			if err = os.MkdirAll(path, info.Mode()); err != nil {
+				jsThrow(call, err)
+			}
+			continue
+		}
+
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY,
+			info.Mode())
+		if err != nil {
+			jsThrow(call, err)
+		}
+		defer file.Close()
+		_, err = io.Copy(file, tarReader)
+		if err != nil {
+			jsThrow(call, err)
+		}
+	}
+	return otto.Value{}
+}

--- a/src/conduit/info/version.go
+++ b/src/conduit/info/version.go
@@ -1,0 +1,3 @@
+package info
+
+var ConduitVersion = "0.3"

--- a/src/conduit/info/version.go
+++ b/src/conduit/info/version.go
@@ -1,3 +1,3 @@
 package info
 
-var ConduitVersion = "0.3"
+var ConduitVersion = "0.2"

--- a/src/postmaster/api/api.go
+++ b/src/postmaster/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"conduit/info"
 	"conduit/log"
 	"crypto/hmac"
 	"crypto/sha256"
@@ -11,6 +12,7 @@ import (
 
 type (
 	ApiRequest struct {
+		Version       string `json:"version"`
 		Signature     string `json:"signature"`
 		RequestTime   string `json:"requestTime"`
 		AccessKeyName string `json:"keyName"`
@@ -27,6 +29,7 @@ type (
 		Body           string   `json:"body"`
 		Pattern        string   `json:"pattern"`
 		DeploymentName string   `json:"deploymentName"`
+		Asset          string   `json:"asset"`
 	}
 
 	PutMessageResponse struct {
@@ -49,6 +52,7 @@ type (
 		CreatedAt    time.Time `json:"createdAt"`
 		ReceiveCount int64     `json:"receiveCount"`
 		Deployment   string    `json:"deployment"`
+		Asset        string    `json:"asset"`
 	}
 	DeleteMessageRequest struct {
 		ApiRequest
@@ -144,6 +148,20 @@ type (
 		Success bool
 		Error   string
 	}
+
+	UploadFileRequest struct {
+		ApiRequest
+		Filename string `json:"filename"`
+		MD5      string `json:"md5"`
+	}
+	CheckFileRequest struct {
+		ApiRequest
+		MD5 string `json:"md5"`
+	}
+	GetAssetRequest struct {
+		ApiRequest
+		MD5 string `json:"md5"`
+	}
 )
 
 func (r *GetMessageResponse) IsEmpty() bool {
@@ -160,6 +178,7 @@ func (request *ApiRequest) Sign(keyName, secret string) {
 	request.AccessKeyName = keyName
 	request.RequestTime = time.Now().Format(time.RFC3339)
 	request.Token = token
+	request.Version = info.ConduitVersion
 	key := []byte(secret)
 	h := hmac.New(sha256.New, key)
 	sig := token + request.RequestTime

--- a/src/postmaster/client/client.go
+++ b/src/postmaster/client/client.go
@@ -2,12 +2,18 @@ package client
 
 import (
 	"bytes"
+	"conduit/log"
+	"crypto/md5"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"mime/multipart"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"postmaster/api"
 	"time"
 )
@@ -24,15 +30,12 @@ type Client struct {
 	ProxyAddress  string
 }
 
-// request wraps HTTP requests to the postmaster server. It is used internally
-// by other functions to make various API requests. It uses a request object and
-// a pointer to an empty repsonse object from the api package.
-func (client *Client) request(endpoint string, req interface{}, res interface{}) error {
+func (client *Client) getHttpClient() (*http.Client, error) {
 	var hClient *http.Client
 	if client.UseProxy {
 		pxUrl, err := url.Parse(client.ProxyAddress)
 		if err != nil {
-			return errors.New("Invalid proxy address")
+			return nil, errors.New("Invalid proxy address")
 		}
 		hClient = &http.Client{
 			Timeout:   0,
@@ -40,6 +43,17 @@ func (client *Client) request(endpoint string, req interface{}, res interface{})
 		}
 	} else {
 		hClient = &http.Client{Timeout: 0}
+	}
+	return hClient, nil
+}
+
+// request wraps HTTP requests to the postmaster server. It is used internally
+// by other functions to make various API requests. It uses a request object and
+// a pointer to an empty repsonse object from the api package.
+func (client *Client) request(endpoint string, req interface{}, res interface{}) error {
+	hClient, err := client.getHttpClient()
+	if err != nil {
+		return err
 	}
 
 	http.DefaultClient.Timeout = 0
@@ -57,6 +71,9 @@ func (client *Client) request(endpoint string, req interface{}, res interface{})
 	}
 	if resp.StatusCode == 404 {
 		return errors.New("API endpoint not found")
+	}
+	if resp.StatusCode == 426 {
+		log.Warn("Server version does not match")
 	}
 	if resp.StatusCode != 200 {
 		var errorResponse api.ApiError
@@ -87,12 +104,30 @@ func (client *Client) Get() (*api.GetMessageResponse, error) {
 // provided, as well as a pattern using '*' as wildcards. The message will by
 // sent to all matching mailboxes.
 func (client *Client) Put(mbxs []string, pattern string, msg string,
-	deploymentName string) (*api.PutMessageResponse, error) {
+	deploymentName string, asset string) (*api.PutMessageResponse, error) {
+	md5, _ := client.hashFile(asset)
+	if asset != "" {
+		exists, err := client.CheckRemoteFile(md5)
+		if err != nil {
+			return nil, err
+		}
+		if exists == true {
+			log.Info("File exists on server, skipping upload")
+		} else {
+			_, err := client.Upload(asset)
+			if err != nil {
+				log.Debug(err.Error())
+				return nil, errors.New("Could not upload asset")
+			}
+		}
+	}
+
 	request := api.PutMessageRequest{
 		Mailboxes:      mbxs,
 		Body:           msg,
 		Pattern:        pattern,
 		DeploymentName: deploymentName,
+		Asset:          md5,
 	}
 	request.Sign(client.AccessKeyName, client.AccessKey)
 	var response api.PutMessageResponse
@@ -229,11 +264,15 @@ func (client *Client) RegisterMailbox(m string) (*api.RegisterResponse, error) {
 	request.Sign(client.AccessKeyName, client.AccessKey)
 	var response *api.RegisterResponse
 	err := client.request("register", request, &response)
+	if err != nil {
+		return nil, err
+	}
 	if !response.Validate(client.AccessKey) {
 		return nil, errors.New("Could not validate signature")
 	}
 	return response, err
 }
+
 func (client *Client) DeregisterMailbox(m string) (*api.SimpleResponse, error) {
 	request := &api.RegisterRequest{Mailbox: m}
 	request.Sign(client.AccessKeyName, client.AccessKey)
@@ -243,4 +282,145 @@ func (client *Client) DeregisterMailbox(m string) (*api.SimpleResponse, error) {
 		return nil, errors.New("Could not validate signature")
 	}
 	return response, err
+}
+
+func (client *Client) hashFile(fp string) (string, error) {
+	file, err := os.Open(fp)
+	if file != nil {
+		defer file.Close()
+	}
+	if err != nil {
+		return "", err
+	}
+	hash := md5.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	hashStr := fmt.Sprintf("%x", hash.Sum(nil))
+	return hashStr, nil
+}
+
+func (client *Client) Upload(fpath string) (*api.SimpleResponse, error) {
+
+	var (
+		body   = &bytes.Buffer{}
+		writer = multipart.NewWriter(body)
+		req    = api.UploadFileRequest{Filename: filepath.Base(fpath)}
+		err    error
+	)
+
+	req.MD5, err = client.hashFile(fpath)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Infof("Uploading file %s", fpath)
+
+	hClient, err := client.getHttpClient()
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("http://%s/%s", client.Host, "upload")
+
+	// Write JSON data as post param
+	req.Sign(client.AccessKeyName, client.AccessKey)
+	requestBytes, err := json.Marshal(req)
+
+	err = writer.WriteField("data", string(requestBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	// Write file to request
+	file, err := os.Open(fpath)
+	if file != nil {
+		defer file.Close()
+	}
+	if err != nil {
+		return nil, err
+	}
+	part, err := writer.CreateFormFile("file", fpath)
+	if err != nil {
+		return nil, err
+	}
+	_, err = io.Copy(part, file)
+	writer.Close()
+
+	// Make the request
+	hReq, err := http.NewRequest("POST", url, body)
+	hReq.Header.Set("Content-Type", writer.FormDataContentType())
+	resp, err := hClient.Do(hReq)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Read the response
+	responseData, _ := ioutil.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		var errorResponse api.ApiError
+		json.Unmarshal(responseData, &errorResponse)
+		return nil, errors.New(errorResponse.Error)
+	}
+	res := &api.SimpleResponse{}
+	json.Unmarshal(responseData, res)
+	return res, err
+}
+
+// Checks if the remote server has a specified file. Before upload a file this
+// method is called to verify that the server does not already contian this
+// file. That way clients do not upload the file when unnessecary.
+func (client *Client) CheckRemoteFile(md5 string) (bool, error) {
+	req := &api.CheckFileRequest{MD5: md5}
+	req.Sign(client.AccessKeyName, client.AccessKey)
+	resp := api.SimpleResponse{}
+	err := client.request("checkfile", req, &resp)
+	if err != nil {
+		return false, err
+	}
+	return resp.Success, nil
+}
+
+func (client *Client) DownloadAsset(md5 string) (string, error) {
+	tmpFile, err := ioutil.TempFile("", "conduit.")
+	if err != nil {
+		return "", err
+	}
+	defer tmpFile.Close()
+
+	req := api.GetAssetRequest{
+		MD5: md5,
+	}
+	req.Sign(client.AccessKeyName, client.AccessKey)
+
+	requestBytes, err := json.Marshal(req)
+	if err != nil {
+		return "", err
+	}
+
+	url := fmt.Sprintf("http://%s/%s", client.Host, "asset")
+	if client.ShowRequests {
+		log.Infof("URL: %s\nRequest: %s", url, string(requestBytes))
+	}
+
+	requestReader := bytes.NewReader(requestBytes)
+	resp, err := http.Post(url, "application/json", requestReader)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode == 200 {
+		_, err = io.Copy(tmpFile, resp.Body)
+		if err != nil {
+			return "", err
+		}
+		return tmpFile.Name(), nil
+	} else {
+		return "", errors.New(fmt.Sprintf("Could not download asset (%d)",
+			resp.StatusCode))
+	}
 }

--- a/src/postmaster/mailbox/db.go
+++ b/src/postmaster/mailbox/db.go
@@ -13,46 +13,60 @@ var DB *ql.DB
 func CreateDB() error {
 	_, _, err := DB.Run(ql.NewRWCtx(), `
 			BEGIN TRANSACTION;
+			CREATE TABLE properties (
+				key string,
+				value string
+			);
+
+			INSERT INTO 	properties
+			VALUES 				("dbversion", "1");
+
 			CREATE TABLE message (
-				id string,
-				receiveCount int,
-				mailbox string,
-				createdAt time,
-				lastReceivedAt time,
-				deployment string,
-				deleted bool
+				id 							string,
+				receiveCount 		int,
+				mailbox 				string,
+				createdAt 			time,
+				lastReceivedAt 	time,
+				deployment 			string,
+				deleted 				bool
 			);
+
 			CREATE TABLE mailbox (
-				id string,
-				completedMessages int,
-				createdAt time,
-				lastCompletedAt time,
-				lastCheckedInAt time
+				id  								string,
+				completedMessages 	int,
+				createdAt 					time,
+				lastCompletedAt 		time,
+				lastCheckedInAt 		time
 			);
+
 			CREATE TABLE accessToken (
-				mailbox string,
-				token string,
-				name string,
-				fullAccess bool
+				mailbox 		string,
+				token 			string,
+				name 				string,
+				fullAccess 	bool
 			);
+
 			CREATE TABLE deployment (
-				id string,
-				messageBody string,
-				name string,
-				deployedAt time,
-				deployedBy string,
+				id 						string,
+				messageBody 	string,
+				name 					string,
+				deployedAt 		time,
+				deployedBy 		string,
 				totalMessages int,
-				open bool
+				open 					bool,
+				asset 				string
 			);
+
 			CREATE TABLE deploymentResponse (
-				deployment string,
-				mailbox string,
-				response string,
-				respondedAt time,
-				isError bool
+				deployment 		string,
+				mailbox 			string,
+				response 			string,
+				respondedAt 	time,
+				isError 			bool
 			);
-			INSERT INTO accessToken (mailbox, token, name, fullAccess)
-			VALUES ("conduit.system", "SYSTEM", "conduit.system", false);
+
+			INSERT INTO 	accessToken (mailbox, token, name, fullAccess)
+			VALUES 				("conduit.system", "SYSTEM", "conduit.system", false);
 			COMMIT;`)
 	return err
 }

--- a/src/postmaster/mailbox/message.go
+++ b/src/postmaster/mailbox/message.go
@@ -33,10 +33,14 @@ func (m *Message) Create() error {
 }
 func (m *Message) Save() error {
 	_, _, err := DB.Run(ql.NewRWCtx(), `
-		BEGIN TRANSACTIOn;
+		BEGIN TRANSACTION;
 		UPDATE message
 		SET receiveCount = $2, mailbox = $3, createdAt = $4, deployment = $5,
 			deleted = $6
 		WHERE id = $1`, m.Id, m.Mailbox, m.CreatedAt, m.Deployment, m.Deleted)
 	return err
+}
+
+func (m *Message) GetDeployment() (*Deployment, error) {
+	return FindDeployment(m.Deployment)
 }

--- a/src/postmaster/server/accept_file.go
+++ b/src/postmaster/server/accept_file.go
@@ -1,0 +1,143 @@
+package server
+
+import (
+	"conduit/log"
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"github.com/kardianos/osext"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"postmaster/api"
+	"postmaster/mailbox"
+)
+
+func acceptFile(w http.ResponseWriter, r *http.Request) {
+	var (
+		request = api.UploadFileRequest{}
+	)
+	// parse form post data
+	err := r.ParseMultipartForm(1000)
+	if err != nil {
+		sendError(w, err.Error())
+		return
+	}
+
+	// Get reuqest data and unmarshal
+	reqData := r.FormValue("data")
+	err = json.Unmarshal([]byte(reqData), &request)
+	if err != nil {
+		sendError(w, "Could not parse request!")
+		return
+	}
+	accessKey, _ := mailbox.FindKeyByName(request.AccessKeyName)
+	if accessKey == nil {
+		sendError(w, "Invalid access key")
+		return
+	}
+	if !accessKey.CanAdmin() {
+		sendError(w, "Not allowed to upload files")
+		return
+	}
+	if !request.Validate(accessKey.Secret) {
+		sendError(w, "Invalid signature")
+		return
+	}
+
+	// Save the posted file
+	file, _, err := r.FormFile("file")
+	if file != nil {
+		defer file.Close()
+	}
+	if err != nil {
+		sendError(w, err.Error())
+		return
+	}
+
+	path := filepath.Join(filesPath(), request.MD5)
+	out, err := os.Create(path)
+	if out != nil {
+		defer out.Close()
+	}
+	if err != nil {
+		sendError(w, err.Error())
+		return
+	}
+	_, err = io.Copy(out, file)
+	if err != nil {
+		sendError(w, err.Error())
+		return
+	}
+	out.Close()
+
+	fileHash, err := hashFile(path)
+	if err != nil {
+		sendError(w, err.Error())
+		return
+	}
+
+	if request.MD5 != fileHash {
+		defer os.Remove(filepath.Join(filesPath(), request.MD5))
+		sendError(w, fmt.Sprintf("MD5 missmatch %s != %s", request.MD5, fileHash))
+		return
+	}
+
+	log.Infof("File uploaded %s", request.MD5)
+	response := api.SimpleResponse{Success: true}
+	response.Sign(accessKey.Name, accessKey.Secret)
+	writeResponse(&w, response)
+}
+
+func filesPath() string {
+	binPath, _ := osext.ExecutableFolder()
+	path := filepath.Join(binPath, "files")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		os.MkdirAll(path, 0755)
+	}
+	return path
+}
+
+func hashFile(fp string) (string, error) {
+	file, err := os.Open(fp)
+	if file != nil {
+		defer file.Close()
+	}
+	if err != nil {
+		return "", err
+	}
+	hash := md5.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	hashStr := fmt.Sprintf("%x", hash.Sum(nil))
+	return hashStr, nil
+}
+
+func checkfile(w http.ResponseWriter, r *http.Request) {
+
+	req := api.CheckFileRequest{}
+	err := readRequest(r, &req)
+	if err != nil {
+		sendError(w, "Could not parse request")
+		return
+	}
+
+	accessKey, _ := mailbox.FindKeyByName(req.AccessKeyName)
+	if accessKey == nil {
+		sendError(w, "Access key invalid")
+		return
+	}
+
+	path := filepath.Join(filesPath(), req.MD5)
+
+	resp := api.SimpleResponse{}
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		resp.Success = false
+	} else {
+		resp.Success = true
+	}
+	resp.Sign(accessKey.Name, accessKey.Secret)
+	writeResponse(&w, resp)
+}

--- a/src/postmaster/server/client_stats.go
+++ b/src/postmaster/server/client_stats.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"net/http"
+	"postmaster/api"
+	"postmaster/mailbox"
+)
+
+// clientStats reports all mailboxes and their current connection status.
+func clientStats(w http.ResponseWriter, r *http.Request) {
+	var request api.SimpleRequest
+	err := readRequest(r, &request)
+	if err != nil {
+		sendError(w, "Bad request")
+	}
+
+	accessKey, err := mailbox.FindKeyByName(request.AccessKeyName)
+	if err != nil || accessKey == nil {
+		sendError(w, "Access key is invalid")
+		return
+	}
+
+	if !accessKey.CanAdmin() {
+		sendError(w, "Not allowed to get statistics")
+		return
+	}
+
+	if !request.Validate(accessKey.Secret) {
+		sendError(w, "Could not validate signature")
+		return
+	}
+
+	clients := make(map[string]bool)
+	mbxs, err := mailbox.All()
+	if err != nil {
+		sendError(w, err.Error())
+		return
+	}
+	for _, mb := range mbxs {
+		if _, ok := pollingChannels[mb.Id]; ok {
+			clients[mb.Id] = true
+		} else {
+			clients[mb.Id] = false
+		}
+	}
+	response := api.ClientStatusResponse{Clients: clients}
+	response.Sign(accessKey.Name, accessKey.Secret)
+	writeResponse(&w, response)
+}

--- a/src/postmaster/server/delete_message.go
+++ b/src/postmaster/server/delete_message.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"conduit/log"
+	"net/http"
+	"postmaster/api"
+	"postmaster/mailbox"
+)
+
+// deleteMessage is used by clients to mark messages as processed. The message
+// remains in the database, but is marked deleted and will no longer be
+// presented to polling clients.
+func deleteMessage(w http.ResponseWriter, r *http.Request) {
+	var request api.DeleteMessageRequest
+	err := readRequest(r, &request)
+	if err != nil {
+		sendError(w, "Could not parse json request")
+		return
+	}
+
+	accessKey, _ := mailbox.FindKeyByName(request.AccessKeyName)
+	if accessKey == nil {
+		sendError(w, "Access key invalid")
+		return
+	}
+
+	if !request.Validate(accessKey.Secret) {
+		sendError(w, "Signature is invalid")
+		return
+	}
+
+	err = mailbox.DeleteMessage(request.Message)
+	if err != nil {
+		sendError(w, "Could not delete message")
+		return
+	}
+	resp := api.DeleteMessageResponse{Message: request.Message}
+	resp.Sign(accessKey.Name, accessKey.Secret)
+	log.Infof("Message %s deleted", request.Message)
+	writeResponse(&w, resp)
+}

--- a/src/postmaster/server/deploy_info.go
+++ b/src/postmaster/server/deploy_info.go
@@ -1,0 +1,111 @@
+package server
+
+import (
+	"conduit/log"
+	"net/http"
+	"postmaster/api"
+	"postmaster/mailbox"
+)
+
+// deployInfo is used to both report a list of recent deployments and get
+// details and responses on a specific deployment.
+func deployInfo(w http.ResponseWriter, r *http.Request) {
+	var request api.DeploymentStatsRequest
+	err := readRequest(r, &request)
+	if err != nil {
+		sendError(w, "Could not parse request")
+		return
+	}
+
+	if request.NamePattern == "" {
+		request.NamePattern = ".*"
+	}
+
+	if request.TokenPattern == "" {
+		request.TokenPattern = ".*"
+	}
+
+	accessKey, err := mailbox.FindKeyByName(request.AccessKeyName)
+	if err != nil || accessKey == nil {
+		sendError(w, "Access key is invalid")
+		return
+	}
+	if !accessKey.CanAdmin() {
+		sendError(w, "Not allowed to list deployments")
+		return
+	}
+	if !request.Validate(accessKey.Secret) {
+		sendError(w, "Signature invalid")
+		return
+	}
+	response := api.DeploymentStatsResponse{}
+	if request.Deployment == "" {
+		log.Infof("Listing all deploys for %s", accessKey.Name)
+		deployments, err := mailbox.ListDeployments(request.NamePattern,
+			int(request.Count), request.TokenPattern)
+		if err != nil {
+			sendError(w, err.Error())
+			return
+		}
+		for _, d := range deployments {
+			dStats, err := d.Stats()
+			if err != nil {
+				sendError(w, err.Error())
+				return
+			}
+			statsResp := api.DeploymentStats{
+				Name:          d.Name,
+				Id:            d.Id,
+				PendingCount:  dStats.PendingCount,
+				MessageCount:  dStats.MessageCount,
+				ResponseCount: dStats.ResponseCount,
+				CreatedAt:     d.DeployedAt,
+				DeployedBy:    d.DeployedBy,
+			}
+			response.Deployments = append(response.Deployments, statsResp)
+		}
+	} else {
+		dep, err := mailbox.FindDeployment(request.Deployment)
+		if err != nil {
+			sendError(w, err.Error())
+			return
+		}
+
+		if dep == nil {
+			sendError(w, "Deployment not found")
+			return
+		}
+
+		dStats, err := dep.Stats()
+		if err != nil {
+			sendError(w, err.Error())
+			return
+		}
+		deploymentResponses, err := dep.GetResponses()
+		if err != nil {
+			sendError(w, err.Error())
+			return
+		}
+		statsResp := api.DeploymentStats{
+			Name:          dep.Name,
+			Id:            dep.Id,
+			PendingCount:  dStats.PendingCount,
+			MessageCount:  dStats.MessageCount,
+			ResponseCount: dStats.ResponseCount,
+			CreatedAt:     dep.DeployedAt,
+			Responses:     []api.DeploymentResponse{},
+		}
+		for _, r := range deploymentResponses {
+			apiR := api.DeploymentResponse{
+				Mailbox:     r.Mailbox,
+				Response:    r.Response,
+				RespondedAt: r.RespondedAt,
+				IsError:     r.IsError,
+			}
+			statsResp.Responses = append(statsResp.Responses, apiR)
+		}
+		response.Deployments = append(response.Deployments, statsResp)
+	}
+	response.Sign(accessKey.Name, accessKey.Secret)
+	writeResponse(&w, response)
+}

--- a/src/postmaster/server/deploy_respond.go
+++ b/src/postmaster/server/deploy_respond.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"conduit/log"
+	"net/http"
+	"postmaster/api"
+	"postmaster/mailbox"
+)
+
+// deployRespond is used by scripts to "respond" with information from the
+// remote system. These responses can then be reported to the admin client that
+// deployed the original script.
+func deployRespond(w http.ResponseWriter, r *http.Request) {
+	var request api.ResponseRequest
+	err := readRequest(r, &request)
+
+	if err != nil {
+		sendError(w, "Could not parse request")
+		return
+	}
+	accessKey, err := mailbox.FindKeyByName(request.AccessKeyName)
+	if accessKey == nil {
+		sendError(w, "Access key is not valid")
+		return
+	}
+
+	if !request.Validate(accessKey.Secret) {
+		sendError(w, "Could not validate signature")
+		return
+	}
+
+	msg, err := mailbox.FindMessage(request.Message)
+	if err != nil {
+		sendError(w, err.Error())
+		return
+	}
+
+	if msg == nil {
+		sendError(w, "Could not find message "+request.Message)
+		return
+	}
+
+	mb, err := mailbox.Find(msg.Mailbox)
+	if err != nil {
+		sendError(w, err.Error())
+		return
+	}
+
+	if mb == nil {
+		sendError(w, "Mailbox not found")
+		return
+	}
+
+	dep, err := mailbox.FindDeployment(msg.Deployment)
+	if err != nil {
+		sendError(w, err.Error())
+		return
+	}
+	if dep == nil {
+		sendError(w, "Could not find deployment "+msg.Deployment)
+		return
+	}
+	if !accessKey.CanGet(mb) {
+		sendError(w, "Not allowed to respond to deploys")
+		return
+	}
+	err = dep.AddResponse(msg.Mailbox, request.Response, request.Error)
+	if err != nil {
+		sendError(w, err.Error())
+		return
+	}
+	response := api.SimpleResponse{Success: true}
+	response.Sign(accessKey.Name, accessKey.Secret)
+	log.Infof("Reponse added to %s from %s", dep.Id, msg.Mailbox)
+	writeResponse(&w, response)
+}

--- a/src/postmaster/server/deregister.go
+++ b/src/postmaster/server/deregister.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"net/http"
+	"postmaster/api"
+	"postmaster/mailbox"
+)
+
+// deregister is used by administrative clients to remove mailboxes. It deletes
+// the mailbox and all messages from the database.
+func deregister(w http.ResponseWriter, r *http.Request) {
+	var request api.RegisterRequest
+	err := readRequest(r, &request)
+	if err != nil {
+		sendError(w, err.Error())
+		return
+	}
+	accessKey, _ := mailbox.FindKeyByName(request.AccessKeyName)
+	if accessKey == nil {
+		sendError(w, "Access key is invalid")
+		return
+	}
+	if !request.Validate(accessKey.Secret) {
+		sendError(w, "Could not validate signature")
+		return
+	}
+	if !accessKey.CanAdmin() {
+		sendError(w, "Not allowed to deregister mailboxes")
+		return
+	}
+	err = mailbox.Deregister(request.Mailbox)
+	if err != nil {
+		sendError(w, err.Error())
+		return
+	}
+	resp := api.SimpleResponse{Success: true}
+	resp.Sign(accessKey.Name, accessKey.Secret)
+	writeResponse(&w, resp)
+}

--- a/src/postmaster/server/get_asset.go
+++ b/src/postmaster/server/get_asset.go
@@ -1,0 +1,43 @@
+package server
+
+import (
+	"conduit/log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"postmaster/api"
+	"postmaster/mailbox"
+)
+
+func getAsset(w http.ResponseWriter, r *http.Request) {
+	var (
+		request = api.GetAssetRequest{}
+	)
+
+	err := readRequest(r, &request)
+	if err != nil {
+		sendError(w, err.Error())
+		return
+	}
+
+	accessKey, err := mailbox.FindKeyByName(request.AccessKeyName)
+	if accessKey == nil {
+		sendError(w, "Access key is invalid")
+		return
+	}
+
+	if !request.Validate(accessKey.Secret) {
+		sendError(w, "Could not validate signature")
+		return
+	}
+
+	fp := filepath.Join(filesPath(), request.MD5)
+	if _, err := os.Stat(fp); os.IsNotExist(err) {
+		sendError(w, "Asset not found on server")
+		return
+	}
+
+	log.Infof("Serving asset to %s", accessKey.Name)
+	http.ServeFile(w, r, fp)
+
+}

--- a/src/postmaster/server/get_message.go
+++ b/src/postmaster/server/get_message.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	"conduit/log"
+	"fmt"
+	"net/http"
+	"postmaster/api"
+	"postmaster/mailbox"
+	"time"
+)
+
+// getMessage is used by clients to poll for mailbox messages. This method will
+// search the database for messages for the given mailbox. If the mailbox is
+// empty and long_polling is enabled it will create a channel and add it to
+// pollingChannels. It will then wait for a message to be pushed to that
+// channel. It will then continue to output that message. Messages are pushed by
+// the putMessage method.
+func getMessage(w http.ResponseWriter, r *http.Request) {
+	if !EnableLongPolling {
+		time.Sleep(ThrottleDelay)
+	}
+	var request api.GetMessageRequest
+	err := readRequest(r, &request)
+	if err != nil {
+		sendError(w, err.Error())
+		return
+	}
+
+	validateVersion(w, request.Version)
+
+	log.Info("Message request for " + request.Mailbox)
+
+	mb, err := mailbox.Find(request.Mailbox)
+	if err != nil {
+		sendError(w, err.Error())
+		return
+	}
+
+	if mb == nil {
+		log.Errorf("Could not find a mailbox named '%s'", request.Mailbox)
+		sendError(w, fmt.Sprintf("Mailbox %s not found.", request.Mailbox))
+		return
+	}
+
+	accessKey, err := mailbox.FindKeyByName(request.AccessKeyName)
+	if accessKey == nil {
+		log.Errorf("Could not find an access key named '%s'", request.AccessKeyName)
+		sendError(w, "Access key is invalid")
+		return
+	}
+
+	if !request.Validate(accessKey.Secret) {
+		sendError(w, "Signature is invalid")
+		return
+	}
+
+	if !accessKey.CanGet(mb) {
+		sendError(w, "Not allowed to get messages from this mailbox.")
+		return
+	}
+
+	msg, err := mb.GetMessage()
+	if err != nil {
+		sendError(w, err.Error())
+		return
+	}
+
+	if EnableLongPolling == true && msg == nil {
+		pollingChannels[mb.Id] = make(chan *mailbox.Message)
+		timeout := make(chan bool, 1)
+		go func() {
+			time.Sleep(100 * time.Second)
+			timeout <- true
+		}()
+		select {
+		case m := <-pollingChannels[mb.Id]:
+			msg = m
+		case <-timeout:
+			writeResponse(&w, &api.GetMessageResponse{})
+			delete(pollingChannels, mb.Id)
+			return
+		}
+		delete(pollingChannels, mb.Id)
+	}
+
+	if msg == nil {
+		writeResponse(&w, nil)
+		return
+	}
+
+	dep, err := msg.GetDeployment()
+	if err != nil {
+		sendError(w, err.Error())
+		return
+	}
+
+	response := api.GetMessageResponse{
+		Message:      msg.Id,
+		Body:         msg.Body,
+		CreatedAt:    msg.CreatedAt,
+		ReceiveCount: msg.ReceiveCount,
+		Deployment:   msg.Deployment,
+		Asset:        dep.Asset,
+	}
+
+	response.Sign(accessKey.Name, accessKey.Secret)
+	log.Infof("Delivering message %s", response.Message)
+
+	writeResponse(&w, response)
+}

--- a/src/postmaster/server/put_message.go
+++ b/src/postmaster/server/put_message.go
@@ -1,0 +1,115 @@
+package server
+
+import (
+	"conduit/log"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"postmaster/api"
+	"postmaster/mailbox"
+)
+
+// putMessage is used to deploy messages to mailboxes, etiher by a list of
+// mailboxes or a pattern. Messages are organized into a deployment and
+// persisted to the database. If any receiptients are currently polling the
+// message will be forwarded to that session.
+func putMessage(w http.ResponseWriter, r *http.Request) {
+	var request api.PutMessageRequest
+	err := readRequest(r, &request)
+	if err != nil {
+		sendError(w, "Could not parse request")
+	}
+	mailboxes := []mailbox.Mailbox{}
+	if request.Pattern != "" {
+		results, err := mailbox.Search(request.Pattern)
+		if err != nil {
+			sendError(w, err.Error())
+			return
+		}
+		for _, mb := range results {
+			mailboxes = append(mailboxes, mb)
+		}
+	}
+	for _, mbId := range request.Mailboxes {
+		mb, err := mailbox.Find(mbId)
+		if err != nil {
+			sendError(w, err.Error())
+		}
+		if mb == nil {
+			sendError(w, fmt.Sprintf("Mailbox not found (%s)", mbId))
+			return
+		}
+		mailboxes = append(mailboxes, *mb)
+	}
+
+	if len(mailboxes) == 0 {
+		sendError(w, "No mailboxes specified")
+		return
+	}
+
+	if request.Asset != "" {
+		assetPath := filepath.Join(filesPath(), request.Asset)
+		if _, err := os.Stat(assetPath); os.IsNotExist(err) {
+			sendError(w, "Asset does not exist on server")
+			return
+		}
+	}
+
+	mbList := []string{}
+	// dep, err := mailbox.CreateDeployment(request.DeploymentName, request.Token,
+	// 	request.Body)
+
+	dep := mailbox.Deployment{
+		Name:        request.DeploymentName,
+		DeployedBy:  request.AccessKeyName,
+		MessageBody: request.Body,
+		Asset:       request.Asset,
+	}
+
+	err = dep.Create()
+
+	if err != nil {
+		sendError(w, err.Error())
+		return
+	}
+
+	accessKey, err := mailbox.FindKeyByName(request.AccessKeyName)
+	if err != nil || accessKey == nil {
+		sendError(w, "Access key is invalid")
+		return
+	}
+
+	if !request.Validate(accessKey.Secret) {
+		sendError(w, "Signature not valid")
+		return
+	}
+
+	for _, mb := range mailboxes {
+		if !accessKey.CanPut(&mb) {
+			sendError(w, "Not allowed to send messages to "+mb.Id)
+			return
+		}
+		var msg *mailbox.Message
+		msg, err = dep.Deploy(&mb)
+		mbList = append(mbList, mb.Id)
+		if err != nil {
+			sendError(w, err.Error())
+			return
+		}
+		if pollChannel, ok := pollingChannels[mb.Id]; ok {
+			pollChannel <- msg
+		}
+	}
+
+	resp := api.PutMessageResponse{
+		MessageSize: r.ContentLength,
+		Mailboxes:   mbList,
+		Deployment:  dep.Id,
+	}
+	resp.Sign(accessKey.Name, accessKey.Secret)
+
+	log.Infof("Message received for %d mailboxes from %s", len(mbList),
+		dep.DeployedBy)
+	writeResponse(&w, resp)
+}

--- a/src/postmaster/server/register.go
+++ b/src/postmaster/server/register.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"conduit/log"
+	"net/http"
+	"postmaster/api"
+	"postmaster/mailbox"
+)
+
+// register is used by administrative clients to reigster new mailboxes.
+func register(w http.ResponseWriter, r *http.Request) {
+	var request api.RegisterRequest
+	err := readRequest(r, &request)
+	if err != nil {
+		sendError(w, err.Error())
+		return
+	}
+
+	accessKey, err := mailbox.FindKeyByName(request.AccessKeyName)
+	if accessKey == nil {
+		sendError(w, "Access key is invalid")
+		return
+	}
+
+	if !request.Validate(accessKey.Secret) {
+		sendError(w, "Could not validate signature")
+		return
+	}
+
+	if !accessKey.CanAdmin() {
+		sendError(w, "Not allowed to register mailboxes.")
+		return
+	}
+
+	if mailbox.KeyExists(request.Mailbox) {
+		sendError(w, "An access key already exists with that mailbox name")
+		return
+	}
+
+	mb, err := mailbox.Create(request.Mailbox)
+	if err != nil {
+		sendError(w, err.Error())
+		return
+	}
+
+	mbKey := &mailbox.AccessKey{
+		MailboxId: mb.Id,
+	}
+
+	err = mbKey.Create()
+	if err != nil {
+		sendError(w, err.Error())
+		return
+	}
+
+	resp := api.RegisterResponse{
+		Mailbox:         mb.Id,
+		AccessKeyName:   mbKey.Name,
+		AccessKeySecret: mbKey.Secret,
+	}
+	resp.Sign(accessKey.Name, accessKey.Secret)
+	writeResponse(&w, resp)
+	log.Infof("Mailbox %s registered.", mb.Id)
+}

--- a/src/postmaster/server/server.go
+++ b/src/postmaster/server/server.go
@@ -1,9 +1,10 @@
 package server
 
 import (
+	"conduit/info"
 	"conduit/log"
 	"encoding/json"
-	"fmt"
+	"github.com/kardianos/osext"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -14,33 +15,43 @@ import (
 	"time"
 )
 
-// pollingChannels is used to internally store a map of connected clients that
-// are using long polling. A message is sent to the channel to complete the poll
-// cycle.
-var pollingChannels = make(map[string]chan *mailbox.Message)
+var (
+	// pollingChannels is used to internally store a map of connected clients that
+	// are using long polling. A message is sent to the channel to complete the poll
+	// cycle.
+	pollingChannels = make(map[string]chan *mailbox.Message)
 
-// EnableLongPolling controls if long polling is used. If false than clients
-// will be given an immediate empty repsonse if no messages are waiting for
-// them. If true the connection will be held until a message comes in or until
-// it timesout.
-var EnableLongPolling = true
+	// EnableLongPolling controls if long polling is used. If false than clients
+	// will be given an immediate empty repsonse if no messages are waiting for
+	// them. If true the connection will be held until a message comes in or until
+	// it timesout.
+	EnableLongPolling = true
 
-// ThrottleDelay will delay messages from being pushed to clients. This will
-// artificially throttle the connect and reconnects from the clients.
-var ThrottleDelay = 500 * time.Millisecond
+	// ThrottleDelay will delay messages from being pushed to clients. This will
+	// artificially throttle the connect and reconnects from the clients.
+	ThrottleDelay = 500 * time.Millisecond
 
-var serverRunning = false
+	// serverRunning is set to true before the server begins listening. This is
+	// used to help testing.
+	serverRunning = false
+)
 
-type EndPoint struct {
-	Method  string
-	Regex   *regexp.Regexp
-	Handler http.Handler
-}
+type (
+	// EndPoint repesents an API endpoint for the server and is used in request
+	// routing.
+	EndPoint struct {
+		Method  string
+		Regex   *regexp.Regexp
+		Handler http.Handler
+	}
 
-type EndPointHandler struct {
-	endpoints []*EndPoint
-}
+	// EndPointHandler is a collection of API endpoints.
+	EndPointHandler struct {
+		endpoints []*EndPoint
+	}
+)
 
+// Add will add an endpoint to the handler.
 func (h *EndPointHandler) Add(method string, pattern string,
 	handler func(http.ResponseWriter, *http.Request)) {
 	rx, _ := regexp.Compile(pattern)
@@ -52,6 +63,7 @@ func (h *EndPointHandler) Add(method string, pattern string,
 	h.endpoints = append(h.endpoints, ep)
 }
 
+// ServeHTTP matches the request to the appropriate route and calls its handler.
 func (h *EndPointHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for _, endpoint := range h.endpoints {
 		if endpoint.Regex.MatchString(r.URL.Path) && endpoint.Method == r.Method {
@@ -62,6 +74,7 @@ func (h *EndPointHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	http.NotFound(w, r)
 }
 
+// Start loads the web server and begins listening.
 func Start(addr string) error {
 	if serverRunning == true {
 		return nil
@@ -76,12 +89,15 @@ func Start(addr string) error {
 			}
 		}
 	}
+
 	endpoints := EndPointHandler{}
 	svr := &http.Server{
 		Addr:         addr,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 0,
 	}
+
+	endpoints.Add("GET", `/upgrade`, sendConduitBinary)
 	endpoints.Add("POST", `/get`, getMessage)
 	endpoints.Add("POST", "/put", putMessage)
 	endpoints.Add("POST", "/stats/clients", clientStats)
@@ -91,16 +107,18 @@ func Start(addr string) error {
 	endpoints.Add("POST", "/deploy/respond", deployRespond)
 	endpoints.Add("POST", "/register", register)
 	endpoints.Add("POST", "/deregister", deregister)
+	endpoints.Add("POST", "/upload", acceptFile)
+	endpoints.Add("POST", "/checkfile", checkfile)
+	endpoints.Add("POST", "/asset", getAsset)
 	http.Handle("/", &endpoints)
 	serverRunning = true
 	err := svr.ListenAndServe()
 	return err
 }
 
-func CreateMailbox(id string) (*mailbox.Mailbox, error) {
-	return mailbox.Create(id)
-}
-
+// writeResponse is a helper method that writes arbitrary structures in JSON.
+// The interface passed to this mehtod should be a response structure form the
+// postmaster/api package.
 func writeResponse(w *http.ResponseWriter, response interface{}) error {
 	bytes, err := json.Marshal(response)
 	if err != nil {
@@ -110,6 +128,32 @@ func writeResponse(w *http.ResponseWriter, response interface{}) error {
 	return nil
 }
 
+// sendError is a helper method used to write out error responses. Any message
+// passed to it will be wrapped in an error response and written out.
+func sendError(w http.ResponseWriter, msg string) {
+	e := &api.ApiError{
+		Error: msg,
+	}
+	log.Error(msg)
+	w.WriteHeader(http.StatusBadRequest)
+	writeResponse(&w, e)
+}
+
+// validateVersion is used for version syncing. If the client's version does not
+// match the server's version the status code for the response is changed to
+// 426. The request is allowed to process normally.
+// If the client is configured to version sync it should upgrade after the
+// request finishes.
+func validateVersion(w http.ResponseWriter, version string) {
+	if version != info.ConduitVersion {
+		log.Warn("Client bad version: " + version + " != " + info.ConduitVersion)
+		w.WriteHeader(426)
+	}
+}
+
+// readRequest is a helper method to read the request body and convert it into
+// an arbitrary structure. The structure passed to it should be one of the
+// requests from the postmaster/api package.
 func readRequest(r *http.Request, req interface{}) error {
 	defer r.Body.Close()
 	data, err := ioutil.ReadAll(r.Body)
@@ -120,549 +164,14 @@ func readRequest(r *http.Request, req interface{}) error {
 	return err
 }
 
-func getMessage(w http.ResponseWriter, r *http.Request) {
-	if !EnableLongPolling {
-		time.Sleep(ThrottleDelay)
-	}
-	var request api.GetMessageRequest
-	err := readRequest(r, &request)
-	if err != nil {
-		sendError(w, err.Error())
-		return
-	}
+// sendConduitBinary will transmit the application's binary. It is used by
+// clients to perform version syncs.
+func sendConduitBinary(w http.ResponseWriter, r *http.Request) {
+	log.Info("Upgrade requested")
+	w.Header().Set("Content-Disposition", "attachment; filename=conduit")
+	w.Header().Set("Content-Type", r.Header.Get("Content-Type"))
+	defer r.Body.Close()
 
-	log.Info("Message request for " + request.Mailbox)
-
-	mb, err := mailbox.Find(request.Mailbox)
-	if err != nil {
-		sendError(w, err.Error())
-		return
-	}
-
-	if mb == nil {
-		log.Errorf("Could not find a mailbox named '%s'", request.Mailbox)
-		sendError(w, fmt.Sprintf("Mailbox %s not found.", request.Mailbox))
-		return
-	}
-
-	accessKey, err := mailbox.FindKeyByName(request.AccessKeyName)
-	if accessKey == nil {
-		log.Errorf("Could not find an access key named '%s'", request.AccessKeyName)
-		sendError(w, "Access key is invalid")
-		return
-	}
-
-	if !request.Validate(accessKey.Secret) {
-		sendError(w, "Signature is invalid")
-		return
-	}
-
-	if !accessKey.CanGet(mb) {
-		sendError(w, "Not allowed to get messages from this mailbox.")
-		return
-	}
-
-	msg, err := mb.GetMessage()
-	if err != nil {
-		e := &api.ApiError{Error: err.Error()}
-		writeResponse(&w, e)
-	}
-
-	if EnableLongPolling == true && msg == nil {
-		pollingChannels[mb.Id] = make(chan *mailbox.Message)
-		timeout := make(chan bool, 1)
-		go func() {
-			time.Sleep(100 * time.Second)
-			timeout <- true
-		}()
-		select {
-		case m := <-pollingChannels[mb.Id]:
-			msg = m
-		case <-timeout:
-			writeResponse(&w, &api.GetMessageResponse{})
-			delete(pollingChannels, mb.Id)
-			return
-		}
-		delete(pollingChannels, mb.Id)
-	}
-
-	if msg == nil {
-		writeResponse(&w, nil)
-		return
-	}
-
-	response := api.GetMessageResponse{
-		Message:      msg.Id,
-		Body:         msg.Body,
-		CreatedAt:    msg.CreatedAt,
-		ReceiveCount: msg.ReceiveCount,
-		Deployment:   msg.Deployment,
-	}
-	response.Sign(accessKey.Name, accessKey.Secret)
-	log.Infof("Delivering message %s", response.Message)
-
-	writeResponse(&w, response)
-}
-
-func sendError(w http.ResponseWriter, msg string) {
-	e := &api.ApiError{
-		Error: msg,
-	}
-	w.WriteHeader(http.StatusBadRequest)
-	writeResponse(&w, e)
-}
-
-func putMessage(w http.ResponseWriter, r *http.Request) {
-	var request api.PutMessageRequest
-	err := readRequest(r, &request)
-	if err != nil {
-		sendError(w, "Could not parse request")
-	}
-	mailboxes := []mailbox.Mailbox{}
-	if request.Pattern != "" {
-		results, err := mailbox.Search(request.Pattern)
-		if err != nil {
-			sendError(w, err.Error())
-			return
-		}
-		for _, mb := range results {
-			mailboxes = append(mailboxes, mb)
-		}
-	}
-	for _, mbId := range request.Mailboxes {
-		mb, err := mailbox.Find(mbId)
-		if err != nil {
-			sendError(w, err.Error())
-		}
-		if mb == nil {
-			sendError(w, fmt.Sprintf("Mailbox not found (%s)", mbId))
-			return
-		}
-		mailboxes = append(mailboxes, *mb)
-	}
-
-	if len(mailboxes) == 0 {
-		sendError(w, "No mailboxes specified")
-		return
-	}
-
-	mbList := []string{}
-	// dep, err := mailbox.CreateDeployment(request.DeploymentName, request.Token,
-	// 	request.Body)
-
-	dep := mailbox.Deployment{
-		Name:        request.DeploymentName,
-		DeployedBy:  request.AccessKeyName,
-		MessageBody: request.Body,
-	}
-
-	err = dep.Create()
-
-	if err != nil {
-		sendError(w, err.Error())
-		return
-	}
-
-	accessKey, err := mailbox.FindKeyByName(request.AccessKeyName)
-	if err != nil || accessKey == nil {
-		sendError(w, "Access key is invalid")
-		return
-	}
-
-	if !request.Validate(accessKey.Secret) {
-		sendError(w, "Signature not valid")
-		return
-	}
-
-	for _, mb := range mailboxes {
-		if !accessKey.CanPut(&mb) {
-			sendError(w, "Not allowed to send messages to "+mb.Id)
-			return
-		}
-		var msg *mailbox.Message
-		msg, err = dep.Deploy(&mb)
-		mbList = append(mbList, mb.Id)
-		if err != nil {
-			sendError(w, err.Error())
-			return
-		}
-		if pollChannel, ok := pollingChannels[mb.Id]; ok {
-			pollChannel <- msg
-		}
-	}
-
-	resp := api.PutMessageResponse{
-		MessageSize: r.ContentLength,
-		Mailboxes:   mbList,
-		Deployment:  dep.Id,
-	}
-	resp.Sign(accessKey.Name, accessKey.Secret)
-
-	log.Infof("Message received for %d mailboxes from %s", len(mbList),
-		dep.DeployedBy)
-	writeResponse(&w, resp)
-}
-
-func deleteMessage(w http.ResponseWriter, r *http.Request) {
-	var request api.DeleteMessageRequest
-	err := readRequest(r, &request)
-	if err != nil {
-		sendError(w, "Could not parse json request")
-		return
-	}
-
-	accessKey, _ := mailbox.FindKeyByName(request.AccessKeyName)
-	if accessKey == nil {
-		sendError(w, "Access key invalid")
-		return
-	}
-
-	if !request.Validate(accessKey.Secret) {
-		sendError(w, "Signature is invalid")
-		return
-	}
-
-	err = mailbox.DeleteMessage(request.Message)
-	if err != nil {
-		sendError(w, "Could not delete message")
-		return
-	}
-	resp := api.DeleteMessageResponse{Message: request.Message}
-	resp.Sign(accessKey.Name, accessKey.Secret)
-	log.Infof("Message %s deleted", request.Message)
-	writeResponse(&w, resp)
-}
-
-// systemStats is json endpoint used to retrieve overall statistics. The token
-// used to request the endpoint must have write priviledges.
-func systemStats(w http.ResponseWriter, r *http.Request) {
-	var request api.SimpleRequest
-	err := readRequest(r, &request)
-	if err != nil {
-		sendError(w, "Could not get stats")
-		return
-	}
-
-	accessKey, _ := mailbox.FindKeyByName(request.AccessKeyName)
-
-	if accessKey == nil {
-		sendError(w, "Access key is invalid")
-		return
-	}
-
-	if !accessKey.CanAdmin() {
-		sendError(w, "Not allowed to get statistics")
-		return
-	}
-
-	if !request.Validate(accessKey.Secret) {
-		sendError(w, "Could not validate signature")
-		return
-	}
-
-	stats, err := mailbox.Stats()
-	if err != nil {
-		sendError(w, err.Error())
-		return
-	}
-
-	response := api.SystemStatsResponse{
-		TotalMailboxes:   stats.MailboxCount,
-		PendingMessages:  stats.PendingMessages,
-		ConnectedClients: int64(len(pollingChannels)),
-	}
-	response.Sign(accessKey.Name, accessKey.Secret)
-	writeResponse(&w, response)
-}
-
-func clientStats(w http.ResponseWriter, r *http.Request) {
-	var request api.SimpleRequest
-	err := readRequest(r, &request)
-	if err != nil {
-		sendError(w, "Bad request")
-	}
-
-	accessKey, err := mailbox.FindKeyByName(request.AccessKeyName)
-	if err != nil || accessKey == nil {
-		sendError(w, "Access key is invalid")
-		return
-	}
-
-	if !accessKey.CanAdmin() {
-		sendError(w, "Not allowed to get statistics")
-		return
-	}
-
-	if !request.Validate(accessKey.Secret) {
-		sendError(w, "Could not validate signature")
-		return
-	}
-
-	clients := make(map[string]bool)
-	mbxs, err := mailbox.All()
-	if err != nil {
-		sendError(w, err.Error())
-		return
-	}
-	for _, mb := range mbxs {
-		if _, ok := pollingChannels[mb.Id]; ok {
-			clients[mb.Id] = true
-		} else {
-			clients[mb.Id] = false
-		}
-	}
-	response := api.ClientStatusResponse{Clients: clients}
-	response.Sign(accessKey.Name, accessKey.Secret)
-	writeResponse(&w, response)
-}
-
-func deployInfo(w http.ResponseWriter, r *http.Request) {
-	var request api.DeploymentStatsRequest
-	err := readRequest(r, &request)
-	if err != nil {
-		sendError(w, "Could not parse request")
-		return
-	}
-
-	if request.NamePattern == "" {
-		request.NamePattern = ".*"
-	}
-
-	if request.TokenPattern == "" {
-		request.TokenPattern = ".*"
-	}
-
-	accessKey, err := mailbox.FindKeyByName(request.AccessKeyName)
-	if err != nil || accessKey == nil {
-		sendError(w, "Access key is invalid")
-		return
-	}
-	if !accessKey.CanAdmin() {
-		sendError(w, "Not allowed to list deployments")
-		return
-	}
-	if !request.Validate(accessKey.Secret) {
-		sendError(w, "Signature invalid")
-		return
-	}
-	response := api.DeploymentStatsResponse{}
-	if request.Deployment == "" {
-		log.Infof("Listing all deploys for %s", accessKey.Name)
-		deployments, err := mailbox.ListDeployments(request.NamePattern,
-			int(request.Count), request.TokenPattern)
-		if err != nil {
-			sendError(w, err.Error())
-			return
-		}
-		for _, d := range deployments {
-			dStats, err := d.Stats()
-			if err != nil {
-				sendError(w, err.Error())
-				return
-			}
-			statsResp := api.DeploymentStats{
-				Name:          d.Name,
-				Id:            d.Id,
-				PendingCount:  dStats.PendingCount,
-				MessageCount:  dStats.MessageCount,
-				ResponseCount: dStats.ResponseCount,
-				CreatedAt:     d.DeployedAt,
-				DeployedBy:    d.DeployedBy,
-			}
-			response.Deployments = append(response.Deployments, statsResp)
-		}
-	} else {
-		dep, err := mailbox.FindDeployment(request.Deployment)
-		if err != nil {
-			sendError(w, err.Error())
-			return
-		}
-
-		if dep == nil {
-			sendError(w, "Deployment not found")
-			return
-		}
-
-		dStats, err := dep.Stats()
-		if err != nil {
-			sendError(w, err.Error())
-			return
-		}
-		deploymentResponses, err := dep.GetResponses()
-		if err != nil {
-			sendError(w, err.Error())
-			return
-		}
-		statsResp := api.DeploymentStats{
-			Name:          dep.Name,
-			Id:            dep.Id,
-			PendingCount:  dStats.PendingCount,
-			MessageCount:  dStats.MessageCount,
-			ResponseCount: dStats.ResponseCount,
-			CreatedAt:     dep.DeployedAt,
-			Responses:     []api.DeploymentResponse{},
-		}
-		for _, r := range deploymentResponses {
-			apiR := api.DeploymentResponse{
-				Mailbox:     r.Mailbox,
-				Response:    r.Response,
-				RespondedAt: r.RespondedAt,
-				IsError:     r.IsError,
-			}
-			statsResp.Responses = append(statsResp.Responses, apiR)
-		}
-		response.Deployments = append(response.Deployments, statsResp)
-	}
-	response.Sign(accessKey.Name, accessKey.Secret)
-	writeResponse(&w, response)
-}
-
-func deployRespond(w http.ResponseWriter, r *http.Request) {
-	var request api.ResponseRequest
-	err := readRequest(r, &request)
-
-	if err != nil {
-		sendError(w, "Could not parse request")
-		return
-	}
-	accessKey, err := mailbox.FindKeyByName(request.AccessKeyName)
-	if accessKey == nil {
-		sendError(w, "Access key is not valid")
-		return
-	}
-
-	if !request.Validate(accessKey.Secret) {
-		sendError(w, "Could not validate signature")
-		return
-	}
-
-	msg, err := mailbox.FindMessage(request.Message)
-	if err != nil {
-		sendError(w, err.Error())
-		return
-	}
-
-	if msg == nil {
-		sendError(w, "Could not find message "+request.Message)
-		return
-	}
-
-	mb, err := mailbox.Find(msg.Mailbox)
-	if err != nil {
-		sendError(w, err.Error())
-		return
-	}
-
-	if mb == nil {
-		sendError(w, "Mailbox not found")
-		return
-	}
-
-	dep, err := mailbox.FindDeployment(msg.Deployment)
-	if err != nil {
-		sendError(w, err.Error())
-		return
-	}
-	if dep == nil {
-		sendError(w, "Could not find deployment "+msg.Deployment)
-		return
-	}
-	if !accessKey.CanGet(mb) {
-		sendError(w, "Not allowed to respond to deploys")
-		return
-	}
-	err = dep.AddResponse(msg.Mailbox, request.Response, request.Error)
-	if err != nil {
-		sendError(w, err.Error())
-		return
-	}
-	response := api.SimpleResponse{Success: true}
-	response.Sign(accessKey.Name, accessKey.Secret)
-	log.Infof("Reponse added to %s from %s", dep.Id, msg.Mailbox)
-	writeResponse(&w, response)
-}
-
-func register(w http.ResponseWriter, r *http.Request) {
-	var request api.RegisterRequest
-	err := readRequest(r, &request)
-	if err != nil {
-		sendError(w, err.Error())
-		return
-	}
-
-	accessKey, err := mailbox.FindKeyByName(request.AccessKeyName)
-	if accessKey == nil {
-		sendError(w, "Access key is invalid")
-		return
-	}
-
-	if !request.Validate(accessKey.Secret) {
-		sendError(w, "Could not validate signature")
-		return
-	}
-
-	if !accessKey.CanAdmin() {
-		sendError(w, "Not allowed to register mailboxes.")
-		return
-	}
-
-	if mailbox.KeyExists(request.Mailbox) {
-		sendError(w, "An access key already exists with that mailbox name")
-		return
-	}
-
-	mb, err := mailbox.Create(request.Mailbox)
-	if err != nil {
-		sendError(w, err.Error())
-		return
-	}
-
-	mbKey := &mailbox.AccessKey{
-		MailboxId: mb.Id,
-	}
-
-	err = mbKey.Create()
-	if err != nil {
-		sendError(w, err.Error())
-		return
-	}
-
-	resp := api.RegisterResponse{
-		Mailbox:         mb.Id,
-		AccessKeyName:   mbKey.Name,
-		AccessKeySecret: mbKey.Secret,
-	}
-	resp.Sign(accessKey.Name, accessKey.Secret)
-	writeResponse(&w, resp)
-	log.Infof("Mailbox %s registered.", mb.Id)
-}
-
-func deregister(w http.ResponseWriter, r *http.Request) {
-	var request api.RegisterRequest
-	err := readRequest(r, &request)
-	if err != nil {
-		sendError(w, err.Error())
-		return
-	}
-	accessKey, _ := mailbox.FindKeyByName(request.AccessKeyName)
-	if accessKey == nil {
-		sendError(w, "Access key is invalid")
-		return
-	}
-	if !request.Validate(accessKey.Secret) {
-		sendError(w, "Could not validate signature")
-		return
-	}
-	if !accessKey.CanAdmin() {
-		sendError(w, "Not allowed to deregister mailboxes")
-		return
-	}
-	err = mailbox.Deregister(request.Mailbox)
-	if err != nil {
-		sendError(w, err.Error())
-		return
-	}
-	resp := api.SimpleResponse{Success: true}
-	resp.Sign(accessKey.Name, accessKey.Secret)
-	writeResponse(&w, resp)
+	exePath, _ := osext.Executable()
+	http.ServeFile(w, r, exePath)
 }

--- a/src/postmaster/server/system_stats.go
+++ b/src/postmaster/server/system_stats.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"net/http"
+	"postmaster/api"
+	"postmaster/mailbox"
+)
+
+// systemStats is json endpoint used to retrieve overall statistics. The token
+// used to request the endpoint must have write priviledges.
+func systemStats(w http.ResponseWriter, r *http.Request) {
+	var request api.SimpleRequest
+	err := readRequest(r, &request)
+	if err != nil {
+		sendError(w, "Could not get stats")
+		return
+	}
+
+	accessKey, _ := mailbox.FindKeyByName(request.AccessKeyName)
+
+	if accessKey == nil {
+		sendError(w, "Access key is invalid")
+		return
+	}
+
+	if !accessKey.CanAdmin() {
+		sendError(w, "Not allowed to get statistics")
+		return
+	}
+
+	if !request.Validate(accessKey.Secret) {
+		sendError(w, "Could not validate signature")
+		return
+	}
+
+	stats, err := mailbox.Stats()
+	if err != nil {
+		sendError(w, err.Error())
+		return
+	}
+
+	response := api.SystemStatsResponse{
+		TotalMailboxes:   stats.MailboxCount,
+		PendingMessages:  stats.PendingMessages,
+		ConnectedClients: int64(len(pollingChannels)),
+	}
+	response.Sign(accessKey.Name, accessKey.Secret)
+	writeResponse(&w, response)
+}

--- a/src/tests/postmaster/client/client_test.go
+++ b/src/tests/postmaster/client/client_test.go
@@ -8,17 +8,25 @@ import (
 	"testing"
 )
 
-var pmClient client.Client
-var mb *mailbox.Mailbox
-var accessKey *mailbox.AccessKey
+var (
+	pmClient  client.Client
+	mb        *mailbox.Mailbox
+	accessKey *mailbox.AccessKey
+)
 
 func TestMain(m *testing.M) {
 	// open database in memory for testing
 	mailbox.OpenMemDB()
-	mailbox.CreateDB()
+	err := mailbox.CreateDB()
+	if err != nil {
+		panic(err)
+	}
 
 	// create a default mailbox to use
-	mb, _ = mailbox.Create("mb")
+	mb, err = mailbox.Create("mb")
+	if err != nil {
+		panic(err)
+	}
 
 	// create an access token for the default mailbox
 	accessKey = &mailbox.AccessKey{FullAccess: true}
@@ -60,7 +68,7 @@ func TestClientGet(t *testing.T) {
 func TestClientPut(t *testing.T) {
 	mb1, _ := mailbox.Create("put1")
 	mb2, _ := mailbox.Create("put2")
-	_, err := pmClient.Put([]string{mb1.Id, mb2.Id}, "", "PUT TEST", "")
+	_, err := pmClient.Put([]string{mb1.Id, mb2.Id}, "", "PUT TEST", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +81,7 @@ func TestClientPut(t *testing.T) {
 
 func TestAutoCreateDeploy(t *testing.T) {
 	mb, _ := mailbox.Create("put.autocreate.deploy")
-	msg, err := pmClient.Put([]string{mb.Id}, "", "TEST MESSAGE", "blah")
+	msg, err := pmClient.Put([]string{mb.Id}, "", "TEST MESSAGE", "blah", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/tests/postmaster/server/server_test.go
+++ b/src/tests/postmaster/server/server_test.go
@@ -242,7 +242,10 @@ func TestDelete(t *testing.T) {
 }
 
 func TestBadMailbox(t *testing.T) {
+	key := mailbox.AccessKey{FullAccess: true}
+	key.Create()
 	req := api.GetMessageRequest{Mailbox: "111"}
+	req.Sign(key.Name, key.Secret)
 	var resp api.GetMessageResponse
 	code := doRequest(t, req, &resp, "get")
 	if code != 400 {


### PR DESCRIPTION
Added script asset support

Asset files can now be attached to scripts. When a script is deployed
an asset can be uploaded with it. The server will distribute this file
with the script and it is available from within the script.

These files are stored on the local disk with the server named after their MD5 hash. Clients check for the existence of a file before uploading, so they will only upload files that do not exist on the server.